### PR TITLE
Fix: import the name 'std::cin' into src/dev_mode/main.cpp

### DIFF
--- a/src/dev_mode/main.cpp
+++ b/src/dev_mode/main.cpp
@@ -23,6 +23,7 @@ using namespace cq;
 using std::cout;
 using std::endl;
 using std::string;
+using std::cin;
 using std::wcin;
 using std::wstring;
 using std::getline;


### PR DESCRIPTION
The `cin` is missing when I building the latest code, just a tiny fixing.